### PR TITLE
Remove slash for search path

### DIFF
--- a/layouts/partials/head/scripts.html
+++ b/layouts/partials/head/scripts.html
@@ -456,7 +456,7 @@
 
 
   // ========================== search ==========================
-    {{ $searchURL:= ("/" | absLangURL) }}
+    {{ $searchURL:= ("" | absLangURL) }}
     var searchURL = JSON.parse({{ $searchURL | jsonify }});
     var searchResults = null;
     var searchMenu = null;


### PR DESCRIPTION
When setting a baseURL in the config.toml, for sites such as GitHub where the site is hosted not from the root but from the project path, having this extra slash sets the incorrect path and the index.json file cannot be found